### PR TITLE
Fix missing tools in logs

### DIFF
--- a/python/packages/autogen-ext/src/autogen_ext/models/openai/_openai_client.py
+++ b/python/packages/autogen-ext/src/autogen_ext/models/openai/_openai_client.py
@@ -637,6 +637,7 @@ class BaseOpenAIChatCompletionClient(ChatCompletionClient):
                 response=result.model_dump(),
                 prompt_tokens=usage.prompt_tokens,
                 completion_tokens=usage.completion_tokens,
+                tools=tools,
             )
         )
 


### PR DESCRIPTION
Fix for LLMCallEvent failing to log "tools" passed to BaseOpenAIChatCompletionClient in autogen_ext.models.openai._openai_client.BaseOpenAIChatCompletionClient 

This bug creates problems while inspecting why a certain tool was selected/not selected by the LLM as the list of tools available to the LLM is not present in the logs

## Why are these changes needed?

Added "tools" to the LLMCallEvent to log tools available to the LLM as these were being missed causing difficulties during debugging LLM tool calls.

## Related issue number

https://github.com/microsoft/autogen/issues/6531

## Checks

- [x] I've included any doc changes needed for <https://microsoft.github.io/autogen/>. See <https://github.com/microsoft/autogen/blob/main/CONTRIBUTING.md> to build and test documentation locally.
- [x] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [x] I've made sure all auto checks have passed.
